### PR TITLE
Add Komoju gateway

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gem 'jruby-openssl', :platforms => :jruby
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
   gem 'braintree', '>= 2.0.0'
+  gem 'komoju', github: 'komoju/komoju-ruby'
 end

--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -1,0 +1,92 @@
+require 'json'
+require 'komoju'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class KomojuGateway < Gateway
+      self.live_url = "https://gateway-sandbox.degica.com/api/v1"
+      self.supported_countries = ['JP']
+      self.default_currency = 'JPY'
+      self.money_format = :cents
+      self.homepage_url = 'https://komoju.com/'
+      self.display_name = 'Komoju'
+      self.supported_cardtypes = [:visa, :master, :american_express, :jcb]
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        "bad_verification_value" => "incorrect_cvc",
+        "card_expired" => "expired_card",
+        "card_declined" => "card_declined",
+        "invalid_number" => "invalid_number"
+      }
+
+      def initialize(options = {})
+        requires!(options, :login)
+        @api_key = options[:login]
+        super
+      end
+
+      def purchase(money, payment, options = {})
+        params = {
+          amount: amount(money),
+          description: options[:description],
+          payment_details: payment_details(payment, options),
+          currency: options[:currency] || currency(money),
+          external_order_num: options[:order_id]
+        }
+        commit(params)
+      end
+
+      private
+
+      def payment_details(payment, options)
+        details = if payment.is_a?(CreditCard)
+                    credit_card_payment_details(payment, options)
+                  else
+                    payment
+                  end
+
+        details[:email] = options[:email] if options[:email]
+        details
+      end
+
+      def credit_card_payment_details(card, options)
+        details = {}
+        details[:type] = 'credit_card'
+        details[:number] = card.number
+        details[:month] = card.month
+        details[:year] = card.year
+        details[:verification_value] = card.verification_value
+        details[:given_name] = card.first_name
+        details[:family_name] = card.last_name
+        details
+      end
+
+      def create_payment_request(params)
+        Komoju.connect(@api_key, url: self.live_url).payments.create(params)
+      end
+
+      def api_request(params)
+        response = nil
+        begin
+          response = create_payment_request(params)
+        rescue Excon::Errors::HTTPStatusError => e
+          response = JSON.parse(e.response.body)
+        end
+        response
+      end
+
+      def commit(params)
+        response = api_request(params)
+        success = !response.key?("error")
+        message = success ? "Transaction succeeded" : response["error"]["message"]
+        Response.new(success, message, response,
+                     error_code: success ? nil : error_code(response["error"]["code"]),
+                     authorization: success ? response["id"] : nil)
+      end
+
+      def error_code(code)
+        STANDARD_ERROR_CODE_MAPPING[code] || code
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -291,6 +291,9 @@ itransact:
 jetpay:
   login: TESTTERMINAL
 
+komoju:
+  login: sk_f1dd75ce3d5cad477eac0c827c1cac8eaa51ede3
+
 linkpoint:
   login: STOREID
   pem: |

--- a/test/remote/gateways/remote_komoju_test.rb
+++ b/test/remote/gateways/remote_komoju_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+require 'securerandom'
+
+class RemoteKomojuTest < Test::Unit::TestCase
+  def setup
+    @gateway = KomojuGateway.new(fixtures(:komoju))
+
+    @amount = 100
+    @credit_card = credit_card('4111111111111111')
+    @declined_card = credit_card('4123111111111059')
+    @konbini = {
+      type: 'konbini',
+      store: 'lawson',
+      email: 'test@example.com',
+      phone: '09011112222'
+    }
+
+    @options = {
+      order_id: SecureRandom.uuid,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_credit_card_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction succeeded', response.message
+  end
+
+  def test_successful_konbini_purchase
+    response = @gateway.purchase(@amount, @konbini, @options)
+    assert_success response
+    assert_equal 'Transaction succeeded', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'card_declined', response.error_code
+  end
+
+  def test_invalid_login
+    gateway = KomojuGateway.new(login: 'abc')
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+  end
+end

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -1,0 +1,114 @@
+require 'test_helper'
+
+class KomojuTest < Test::Unit::TestCase
+  def setup
+    @gateway = KomojuGateway.new(login: 'login')
+
+    @credit_card = credit_card
+    @konbini = {
+      type: 'konbini',
+      store: 'lawson',
+      email: 'test@example.com',
+      phone: '09011112222'
+    }
+    @amount = 100
+
+    @options = {order_id: '1', description: 'Store Purchase'}
+  end
+
+  def test_successful_credit_card_purchase
+    successful_response = successful_credit_card_purchase_response
+    @gateway.expects(:create_payment_request).returns(successful_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal successful_response["id"], response.authorization
+  end
+
+  def test_successful_konbini_purchase
+    successful_response = successful_konbini_purchase_response
+    @gateway.expects(:create_payment_request).returns(successful_response)
+
+    response = @gateway.purchase(@amount, @konbini, @options)
+    assert_success response
+
+    assert_equal successful_response["id"], response.authorization
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:create_payment_request).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "missing_parameter", response.error_code
+  end
+
+  private
+
+  def successful_credit_card_purchase_response
+    {
+      "id" => "7e8c55a54256ce23e387f2838c",
+      "resource" => "payment",
+      "status" => "captured",
+      "amount" => 100,
+      "tax" => 8,
+      "payment_deadline" => nil,
+      "payment_details" => {
+        "type" => "credit_card",
+        "brand" => "visa",
+        "last_four_digits" => "2220",
+        "month" => 9,
+        "year" => 2016
+      },
+      "payment_method_fee" => 0,
+      "total" => 108,
+      "currency" => "JPY",
+      "description" => "Store Purchase",
+      "subscription" => nil,
+      "succeeded" => true,
+      "metadata" => {
+        "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
+      },
+      "created_at" => "2015-03-20T04:51:48Z"
+    }
+  end
+
+  def failed_purchase_response
+    {
+      "error" => {
+        "code" => "missing_parameter",
+        "message" => "A required parameter (currency) is missing",
+        "param" => "currency"
+      }
+    }
+  end
+
+  def successful_konbini_purchase_response
+    {
+      "id" => "98f5d7883c951bc21c1dfe947b",
+      "resource" => "payment",
+      "status" => "authorized",
+      "amount" => 1000,
+      "tax" => 80,
+      "payment_deadline" => "2015-03-21T14:59:59Z",
+      "payment_details" => {
+        "type" => "konbini",
+        "store" => "lawson",
+        "confirmation_code" => "3769",
+        "receipt" => "WNT30356930",
+        "instructions_url" => "http://www.degica.com/cvs/lawson"
+      },
+     "payment_method_fee" => 150,
+     "total" => 1230,
+     "currency" => "JPY",
+     "description" => nil,
+     "subscription" => nil,
+     "succeeded" => false,
+     "metadata" => {
+       "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
+     },
+     "created_at" => "2015-03-20T05:45:55Z"
+    }
+  end
+end


### PR DESCRIPTION
Added Komoju gateway. Currently only `purchase` method is supported. When received callback, you don't need to call `capture` since the payment was already captured by the gateway, Komoju.
## Installation

To use Komoju gateway, you need to add the following setting to your `Gemfile`

``` ruby
gem 'komoju', github: 'komoju/komoju-ruby'
gem 'active_merchant', github: 'komoju/active_merchant'
```
## Basic Usage

``` ruby
require 'active_merchant'

gateway = ActiveMerchant::Billing::KomojuGateway.new(login: 'frt-mart')
# => #<ActiveMerchant::Billing::KomojuGateway:0x007fa2f3e6acb0 @api_key="frt-mart", @options={:login=>"frt-mart"}>

## You can use AM's CreditCard class for credit card payment
card = ActiveMerchant::Billing::CreditCard.new number: '4111111111111111', month: '11', year: '2020', first_name: 'TARO', last_name: 'YAMADA', verification_value: '111'

response = gateway.purchase(1000, card, order_id: 'abcdefghjjkdjf')
response.params
#=> {"id"=>"21d7db83d04689760f9e83a9df", "resource"=>"payment", "status"=>"captured", "amount"=>1000, "tax"=>80, "payment_deadline"=>nil, "payment_details"=>{"type"=>"credit_card", "brand"=>"visa", "last_four_digits"=>"1111", "month"=>11, "year"=>2020}, "payment_method_fee"=>0, "total"=>1080, "currency"=>"JPY", "description"=>nil, "subscription"=>nil, "succeeded"=>true, "metadata"=>{"order_id"=>"abcdefghjjkdjf"}, "created_at"=>"2015-03-20T09:10:47Z"}


## Or, you can use Komoju-style payment details
konbini = {
  type: 'konbini',
  store: 'lawson',
  email: 'test@example.com',
  phone: '09011112222'
}

response = gateway.purchase(1000, konbini, order_id: 'abcdefghjjkdjf')
response.params
#=> {"id"=>"be2d5763f60d6477376491974f", "resource"=>"payment", "status"=>"authorized", "amount"=>1000, "tax"=>80, "payment_deadline"=>"2015-03-21T14:59:59Z", "payment_details"=>{"type"=>"konbini", "store"=>"lawson", "confirmation_code"=>"3769", "receipt"=>"WNT42844316", "instructions_url"=>"http://www.degica.com/cvs/lawson"}, "payment_method_fee"=>0, "total"=>1080, "currency"=>"JPY", "description"=>nil, "subscription"=>nil, "succeeded"=>false, "metadata"=>{"order_id"=>"abcdefghjjkdjf"}, "created_at"=>"2015-03-20T09:14:03Z"}
```
