### PR TITLE
Add test mode and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) conta
 * [Iridium](http://www.iridiumcorp.co.uk/) - GB, ES
 * [iTransact](http://www.itransact.com/) - US
 * [JetPay](http://www.jetpay.com/) - US
+* [Komoju](http://www.komoju.com/) - JP
 * [LinkPoint](http://www.linkpoint.com/) - US
 * [Litle & Co.](http://www.litle.com/) - US
 * [maxiPago!](http://www.maxipago.com/) - BR

--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -65,7 +65,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def create_payment_request(params)
-        Komoju.connect(@api_key, :url => url).payments.create(params)
+        client = Komoju.connect(@api_key, :url => url, :default_headers => headers)
+        client.payments.create(params)
       end
 
       def api_request(params)
@@ -94,6 +95,12 @@ module ActiveMerchant #:nodoc:
 
       def url
         test? ? self.test_url : self.live_url
+      end
+
+      def headers
+        {
+          "User-Agent" => "Komoju/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}"
+        }
       end
     end
   end

--- a/test/remote/gateways/remote_komoju_test.rb
+++ b/test/remote/gateways/remote_komoju_test.rb
@@ -9,39 +9,63 @@ class RemoteKomojuTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111')
     @declined_card = credit_card('4123111111111059')
     @konbini = {
-      type: 'konbini',
-      store: 'lawson',
-      email: 'test@example.com',
-      phone: '09011112222'
+      :type  => 'konbini',
+      :store => 'lawson',
+      :email => 'test@example.com',
+      :phone => '09011112222'
+    }
+
+    @bank_transfer = {
+      :type  => 'bank_transfer',
+      :email => 'test@example.com',
+      :phone => '09011112222',
+      :family_name => 'Taro',
+      :given_name => 'Yamada',
+      :family_name_kana => 'Taro',
+      :given_name_kana => 'Yamada'
     }
 
     @options = {
-      order_id: SecureRandom.uuid,
-      description: 'Store Purchase',
-      tax: '10'
+      :order_id => SecureRandom.uuid,
+      :description => 'Store Purchase',
+      :tax => '10.0'
     }
   end
 
   def test_successful_credit_card_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
+    assert response.authorization.present?
     assert_equal 'Transaction succeeded', response.message
+    assert_equal 100, response.params['amount']
+    assert_equal "1111", response.params['payment_details']['last_four_digits']
+    assert_equal true, response.params['succeeded']
   end
 
   def test_successful_konbini_purchase
     response = @gateway.purchase(@amount, @konbini, @options)
     assert_success response
+    assert response.authorization.present?
+    assert_equal 'Transaction succeeded', response.message
+    assert_equal 100, response.params['amount']
+  end
+
+  def test_successful_bank_transfer_purchase
+    response = @gateway.purchase(@amount, @bank_transfer, @options)
+    assert_success response
+    assert response.authorization.present?
     assert_equal 'Transaction succeeded', response.message
   end
 
-  def test_failed_purchase
+  def test_failed_credit_card_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
+    assert response.authorization.blank?
     assert_equal 'card_declined', response.error_code
   end
 
   def test_invalid_login
-    gateway = KomojuGateway.new(login: 'abc')
+    gateway = KomojuGateway.new(:login => 'abc')
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
   end

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -2,18 +2,18 @@ require 'test_helper'
 
 class KomojuTest < Test::Unit::TestCase
   def setup
-    @gateway = KomojuGateway.new(login: 'login')
+    @gateway = KomojuGateway.new(:login => 'login')
 
     @credit_card = credit_card
     @konbini = {
-      type: 'konbini',
-      store: 'lawson',
-      email: 'test@example.com',
-      phone: '09011112222'
+      :type  => 'konbini',
+      :store => 'lawson',
+      :email => 'test@example.com',
+      :phone => '09011112222'
     }
     @amount = 100
 
-    @options = {order_id: '1', description: 'Store Purchase', tax: "10"}
+    @options = {:order_id => '1', description => 'Store Purchase', :tax => "10"}
   end
 
   def test_successful_credit_card_purchase
@@ -24,6 +24,7 @@ class KomojuTest < Test::Unit::TestCase
     assert_success response
 
     assert_equal successful_response["id"], response.authorization
+    assert response.test?
   end
 
   def test_successful_konbini_purchase
@@ -34,6 +35,7 @@ class KomojuTest < Test::Unit::TestCase
     assert_success response
 
     assert_equal successful_response["id"], response.authorization
+    assert response.test?
   end
 
   def test_failed_purchase
@@ -42,6 +44,7 @@ class KomojuTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal "missing_parameter", response.error_code
+    assert response.test?
   end
 
   private

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -39,7 +39,11 @@ class KomojuTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-    @gateway.expects(:create_payment_request).returns(failed_purchase_response)
+    response = mock
+    response.expects(:body).returns(JSON.generate(failed_purchase_response))
+    exception = Excon::Errors::HTTPStatusError.new("", nil, response)
+
+    @gateway.expects(:create_payment_request).raises(exception)
 
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response


### PR DESCRIPTION
- Added test mode
  - without enabling test mode, komoju gateway now requests to `https://komoju.com/api/v1`
  - If you want to use sandbox, use `test` option: `KomojuGateway.new(login: 'login', test: true)`
- Changed to use old-style hash because all other code use old style hash
- Added some tests
- Add "Komoju" to README
