### PR TITLE
Add komoju refund

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) conta
 * [Iridium](http://www.iridiumcorp.co.uk/) - GB, ES
 * [iTransact](http://www.itransact.com/) - US
 * [JetPay](http://www.jetpay.com/) - US
+* [Komoju](http://www.komoju.com/) - JP
 * [LinkPoint](http://www.linkpoint.com/) - US
 * [Litle & Co.](http://www.litle.com/) - US
 * [maxiPago!](http://www.maxipago.com/) - BR

--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -1,0 +1,105 @@
+require 'json'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class KomojuGateway < Gateway
+      self.test_url = "https://sandbox.komoju.com/api/v1"
+      self.live_url = "https://komoju.com/api/v1"
+      self.supported_countries = ['JP']
+      self.default_currency = 'JPY'
+      self.money_format = :cents
+      self.homepage_url = 'https://www.komoju.com/'
+      self.display_name = 'Komoju'
+      self.supported_cardtypes = [:visa, :master, :american_express, :jcb]
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        "bad_verification_value" => "incorrect_cvc",
+        "card_expired" => "expired_card",
+        "card_declined" => "card_declined",
+        "invalid_number" => "invalid_number"
+      }
+
+      def initialize(options = {})
+        requires!(options, :login)
+        @api_key = options[:login]
+        super
+      end
+
+      def purchase(money, payment, options = {})
+        params = {
+          :amount => amount(money),
+          :description => options[:description],
+          :payment_details => payment_details(payment, options),
+          :currency => options[:currency] || currency(money)
+        }
+        params[:external_order_num] = options[:order_id] if options[:order_id]
+        params[:tax] = options[:tax] if options[:tax]
+
+        commit(params)
+      end
+
+      private
+
+      def payment_details(payment, options)
+        details = if payment.is_a?(CreditCard)
+                    credit_card_payment_details(payment, options)
+                  else
+                    payment
+                  end
+
+        details[:email] = options[:email] if options[:email]
+        details
+      end
+
+      def credit_card_payment_details(card, options)
+        details = {}
+        details[:type] = 'credit_card'
+        details[:number] = card.number
+        details[:month] = card.month
+        details[:year] = card.year
+        details[:verification_value] = card.verification_value
+        details[:given_name] = card.first_name
+        details[:family_name] = card.last_name
+        details
+      end
+
+      def api_request(data)
+        raw_response = nil
+        begin
+          raw_response = ssl_post("#{url}/payments", data, headers)
+        rescue ResponseError => e
+          raw_response = e.response.body
+        end
+
+        JSON.parse(raw_response)
+      end
+
+      def commit(params)
+        response = api_request(params.to_json)
+        success = !response.key?("error")
+        message = success ? "Transaction succeeded" : response["error"]["message"]
+        Response.new(success, message, response,
+                     :test => test?,
+                     :error_code => success ? nil : error_code(response["error"]["code"]),
+                     :authorization => success ? response["id"] : nil)
+      end
+
+      def error_code(code)
+        STANDARD_ERROR_CODE_MAPPING[code] || code
+      end
+
+      def url
+        test? ? self.test_url : self.live_url
+      end
+
+      def headers
+        {
+          "Authorization" => "Basic " + Base64.encode64(@api_key.to_s + ":").strip,
+          "Accept" => "application/json",
+          "Content-Type" => "application/json",
+          "User-Agent" => "Komoju/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}"
+        }
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -39,6 +39,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, identification, options = {})
+        commit("/payments/#{identification}/refund", {})
       end
 
       private

--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -35,7 +35,10 @@ module ActiveMerchant #:nodoc:
         params[:external_order_num] = options[:order_id] if options[:order_id]
         params[:tax] = options[:tax] if options[:tax]
 
-        commit(params)
+        commit("/payments", params)
+      end
+
+      def refund(money, identification, options = {})
       end
 
       private
@@ -63,10 +66,10 @@ module ActiveMerchant #:nodoc:
         details
       end
 
-      def api_request(data)
+      def api_request(path, data)
         raw_response = nil
         begin
-          raw_response = ssl_post("#{url}/payments", data, headers)
+          raw_response = ssl_post("#{url}#{path}", data, headers)
         rescue ResponseError => e
           raw_response = e.response.body
         end
@@ -74,8 +77,8 @@ module ActiveMerchant #:nodoc:
         JSON.parse(raw_response)
       end
 
-      def commit(params)
-        response = api_request(params.to_json)
+      def commit(path, params)
+        response = api_request(path, params.to_json)
         success = !response.key?("error")
         message = success ? "Transaction succeeded" : response["error"]["message"]
         Response.new(success, message, response,

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -296,6 +296,9 @@ itransact:
 jetpay:
   login: TESTTERMINAL
 
+komoju:
+  login: sk_f1dd75ce3d5cad477eac0c827c1cac8eaa51ede3
+
 linkpoint:
   login: STOREID
   pem: |

--- a/test/remote/gateways/remote_komoju_test.rb
+++ b/test/remote/gateways/remote_komoju_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+require 'securerandom'
+
+class RemoteKomojuTest < Test::Unit::TestCase
+  def setup
+    @gateway = KomojuGateway.new(fixtures(:komoju))
+
+    @amount = 100
+    @credit_card = credit_card('4111111111111111')
+    @declined_card = credit_card('4123111111111059')
+    @konbini = {
+      :type  => 'konbini',
+      :store => 'lawson',
+      :email => 'test@example.com',
+      :phone => '09011112222'
+    }
+
+    @bank_transfer = {
+      :type  => 'bank_transfer',
+      :email => 'test@example.com',
+      :phone => '09011112222',
+      :family_name => 'Taro',
+      :given_name => 'Yamada',
+      :family_name_kana => 'Taro',
+      :given_name_kana => 'Yamada'
+    }
+
+    @options = {
+      :order_id => SecureRandom.uuid,
+      :description => 'Store Purchase',
+      :tax => '10.0'
+    }
+  end
+
+  def test_successful_credit_card_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert response.authorization.present?
+    assert_equal 'Transaction succeeded', response.message
+    assert_equal 100, response.params['amount']
+    assert_equal "1111", response.params['payment_details']['last_four_digits']
+    assert_equal true, response.params['succeeded']
+  end
+
+  def test_successful_konbini_purchase
+    response = @gateway.purchase(@amount, @konbini, @options)
+    assert_success response
+    assert response.authorization.present?
+    assert_equal 'Transaction succeeded', response.message
+    assert_equal 100, response.params['amount']
+  end
+
+  def test_successful_bank_transfer_purchase
+    response = @gateway.purchase(@amount, @bank_transfer, @options)
+    assert_success response
+    assert response.authorization.present?
+    assert_equal 'Transaction succeeded', response.message
+  end
+
+  def test_failed_credit_card_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert response.authorization.blank?
+    assert_equal 'card_declined', response.error_code
+  end
+
+  def test_invalid_login
+    gateway = KomojuGateway.new(:login => 'abc')
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+  end
+end

--- a/test/remote/gateways/remote_komoju_test.rb
+++ b/test/remote/gateways/remote_komoju_test.rb
@@ -39,7 +39,7 @@ class RemoteKomojuTest < Test::Unit::TestCase
     assert_equal 'Transaction succeeded', response.message
     assert_equal 100, response.params['amount']
     assert_equal "1111", response.params['payment_details']['last_four_digits']
-    assert_equal true, response.params['succeeded']
+    assert_equal true, response.params['captured_at'].present?
   end
 
   def test_successful_credit_card_refund

--- a/test/remote/gateways/remote_komoju_test.rb
+++ b/test/remote/gateways/remote_komoju_test.rb
@@ -42,6 +42,15 @@ class RemoteKomojuTest < Test::Unit::TestCase
     assert_equal true, response.params['succeeded']
   end
 
+  def test_successful_credit_card_refund
+    purchase_response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase_response
+    assert purchase_response.authorization.present?
+    refund_response = @gateway.refund(@amount, purchase_response.authorization, {})
+    assert_success refund_response
+    assert_equal 'refunded', refund_response.params['status']
+  end
+
   def test_successful_konbini_purchase
     response = @gateway.purchase(@amount, @konbini, @options)
     assert_success response

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -1,0 +1,121 @@
+require 'test_helper'
+
+class KomojuTest < Test::Unit::TestCase
+  def setup
+    @gateway = KomojuGateway.new(:login => 'login')
+
+    @credit_card = credit_card
+    @konbini = {
+      :type  => 'konbini',
+      :store => 'lawson',
+      :email => 'test@example.com',
+      :phone => '09011112222'
+    }
+    @amount = 100
+
+    @options = {:order_id => '1', :description => 'Store Purchase', :tax => "10"}
+  end
+
+  def test_successful_credit_card_purchase
+    successful_response = successful_credit_card_purchase_response
+    @gateway.expects(:ssl_post).returns(JSON.generate(successful_response))
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal successful_response["id"], response.authorization
+    assert response.test?
+  end
+
+  def test_successful_konbini_purchase
+    successful_response = successful_konbini_purchase_response
+    @gateway.expects(:ssl_post).returns(JSON.generate(successful_response))
+
+    response = @gateway.purchase(@amount, @konbini, @options)
+    assert_success response
+
+    assert_equal successful_response["id"], response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    raw_response = mock
+    raw_response.expects(:body).returns(JSON.generate(failed_purchase_response))
+    exception = ActiveMerchant::ResponseError.new(raw_response)
+
+    @gateway.expects(:ssl_post).raises(exception)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "missing_parameter", response.error_code
+    assert response.test?
+  end
+
+  private
+
+  def successful_credit_card_purchase_response
+    {
+      "id" => "7e8c55a54256ce23e387f2838c",
+      "resource" => "payment",
+      "status" => "captured",
+      "amount" => 100,
+      "tax" => 8,
+      "payment_deadline" => nil,
+      "payment_details" => {
+        "type" => "credit_card",
+        "brand" => "visa",
+        "last_four_digits" => "2220",
+        "month" => 9,
+        "year" => 2016
+      },
+      "payment_method_fee" => 0,
+      "total" => 108,
+      "currency" => "JPY",
+      "description" => "Store Purchase",
+      "subscription" => nil,
+      "succeeded" => true,
+      "metadata" => {
+        "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
+      },
+      "created_at" => "2015-03-20T04:51:48Z"
+    }
+  end
+
+  def failed_purchase_response
+    {
+      "error" => {
+        "code" => "missing_parameter",
+        "message" => "A required parameter (currency) is missing",
+        "param" => "currency"
+      }
+    }
+  end
+
+  def successful_konbini_purchase_response
+    {
+      "id" => "98f5d7883c951bc21c1dfe947b",
+      "resource" => "payment",
+      "status" => "authorized",
+      "amount" => 1000,
+      "tax" => 80,
+      "payment_deadline" => "2015-03-21T14:59:59Z",
+      "payment_details" => {
+        "type" => "konbini",
+        "store" => "lawson",
+        "confirmation_code" => "3769",
+        "receipt" => "WNT30356930",
+        "instructions_url" => "http://www.degica.com/cvs/lawson"
+      },
+     "payment_method_fee" => 150,
+     "total" => 1230,
+     "currency" => "JPY",
+     "description" => nil,
+     "subscription" => nil,
+     "succeeded" => false,
+     "metadata" => {
+       "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
+     },
+     "created_at" => "2015-03-20T05:45:55Z"
+    }
+  end
+end

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -84,7 +84,7 @@ class KomojuTest < Test::Unit::TestCase
       "currency" => "JPY",
       "description" => "Store Purchase",
       "subscription" => nil,
-      "succeeded" => true,
+      "captured_at" => "2015-03-20T04:51:48Z",
       "metadata" => {
         "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
       },
@@ -112,7 +112,7 @@ class KomojuTest < Test::Unit::TestCase
       "currency" => "JPY",
       "description" => "Store Purchase",
       "subscription" => nil,
-      "succeeded" => false,
+      "captured_at" => nil,
       "metadata" => {
         "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
       },
@@ -150,7 +150,7 @@ class KomojuTest < Test::Unit::TestCase
      "currency" => "JPY",
      "description" => nil,
      "subscription" => nil,
-     "succeeded" => false,
+     "captured_at" => nil,
      "metadata" => {
        "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
      },

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -51,6 +51,17 @@ class KomojuTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_credit_card_refund
+    successful_response = successful_credit_card_refund_response
+    @gateway.expects(:ssl_post).returns(JSON.generate(successful_response))
+
+    response = @gateway.refund(@amount,  "7e8c55a54256ce23e387f2838c", @options)
+    assert_success response
+
+    assert_equal successful_response["id"], response.authorization
+    assert response.test?
+  end
+
   private
 
   def successful_credit_card_purchase_response
@@ -74,6 +85,34 @@ class KomojuTest < Test::Unit::TestCase
       "description" => "Store Purchase",
       "subscription" => nil,
       "succeeded" => true,
+      "metadata" => {
+        "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
+      },
+      "created_at" => "2015-03-20T04:51:48Z"
+    }
+  end
+
+  def successful_credit_card_refund_response
+    {
+      "id" => "7e8c55a54256ce23e387f2838c",
+      "resource" => "payment",
+      "status" => "refunded",
+      "amount" => 100,
+      "tax" => 8,
+      "payment_deadline" => nil,
+      "payment_details" => {
+        "type" => "credit_card",
+        "brand" => "visa",
+        "last_four_digits" => "2220",
+        "month" => 9,
+        "year" => 2016
+      },
+      "payment_method_fee" => 0,
+      "total" => 108,
+      "currency" => "JPY",
+      "description" => "Store Purchase",
+      "subscription" => nil,
+      "succeeded" => false,
       "metadata" => {
         "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
       },


### PR DESCRIPTION
Added Komoju refund support. `refund` method has `money` argument like other gateways but the argument is just ignored because currently Komoju API doesn't support partial refund.
